### PR TITLE
Fixed issues with Drools integration

### DIFF
--- a/api/src/main/java/org/ihtsdo/rvf/autoscaling/InstanceManager.java
+++ b/api/src/main/java/org/ihtsdo/rvf/autoscaling/InstanceManager.java
@@ -54,12 +54,14 @@ public class InstanceManager {
 
 	private String droolsRulesVersion;
 	private String droolsRulesDirectory;
+	private String droolsRulesRepository;
 
-	public InstanceManager(AWSCredentials credentials, String ec2Endpoint, String droolsRulesVersion, String droolsRulesDirectory) {
+	public InstanceManager(AWSCredentials credentials, String ec2Endpoint, String droolsRulesVersion, String droolsRulesDirectory, String droolsRulesRepository) {
 		amazonEC2Client = new AmazonEC2Client(credentials);
 		amazonEC2Client.setEndpoint(ec2Endpoint);
 		this.droolsRulesVersion = droolsRulesVersion;
 		this.droolsRulesDirectory = droolsRulesDirectory;
+		this.droolsRulesRepository = droolsRulesRepository;
 		ec2InstanceStartupScript = Base64.encodeBase64String(constructStartUpScript().getBytes());
 	}
 
@@ -317,7 +319,7 @@ public class InstanceManager {
 			builder.append(" --single-branch");
 		}
 		//"--single-branch https://github.com/IHTSDO/snomed-drools-rules.git /opt/snomed-drools-rules/)
-		builder.append(" https://github.com/IHTSDO/snomed-drools-rules.git ");
+		builder.append(" " + droolsRulesRepository + " ");
 		if (droolsRulesDirectory == null || droolsRulesDirectory.isEmpty() || !droolsRulesDirectory.startsWith("/")) {
 			droolsRulesDirectory= "/opt/snomed-drools-rules/";
 		}

--- a/api/src/main/resources/servletContext.xml
+++ b/api/src/main/resources/servletContext.xml
@@ -75,6 +75,7 @@
 		<constructor-arg ref="ec2Endpoint"/>
        <constructor-arg name="droolsRulesVersion" value="${rvf.drools.rule.version}"/>
        <constructor-arg name="droolsRulesDirectory" value="${rvf.drools.rule.directory}"/>
+		 <constructor-arg name="droolsRulesRepository" value="${rvf.drools.rule.repository}"/>
 	</bean>
     <bean class="org.ihtsdo.rvf.helper.JsonEntityGenerator"/>
     <bean id="resourceProviderFactory" class="org.ihtsdo.rvf.validation.log.impl.ValidationLogFactoryImpl"/>

--- a/execution-service/pom.xml
+++ b/execution-service/pom.xml
@@ -124,11 +124,23 @@
 			<groupId>org.ihtsdo.drools</groupId>
 			<artifactId>snomed-drools-engine</artifactId>
 			<version>${snomed-drools.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.collections</groupId>
+					<artifactId>google-collections</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.ihtsdo.drools</groupId>
 			<artifactId>snomed-drools-rf2-validator</artifactId>
 			<version>${snomed-drools.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.collections</groupId>
+					<artifactId>google-collections</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 </project>

--- a/execution-service/src/main/java/org/ihtsdo/rvf/execution/service/impl/ValidationReportService.java
+++ b/execution-service/src/main/java/org/ihtsdo/rvf/execution/service/impl/ValidationReportService.java
@@ -63,7 +63,7 @@ public class ValidationReportService {
 	}
 	
 	public void writeResults(final Map<String , Object> responseMap, final State state, String storageLocation) throws BusinessServiceException {
-		final Gson prettyGson = new GsonBuilder().setPrettyPrinting().create();
+		final Gson prettyGson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 		File temp = null;
 		try {
 	        temp = File.createTempFile("resultJson", ".tmp"); 

--- a/execution-service/src/main/java/org/ihtsdo/rvf/execution/service/impl/ValidationRunner.java
+++ b/execution-service/src/main/java/org/ihtsdo/rvf/execution/service/impl/ValidationRunner.java
@@ -116,7 +116,8 @@ public class ValidationRunner {
 		report.setExecutionId(validationConfig.getRunId());
 
 		boolean isFailed = structuralTestRunner.verifyZipFileStructure(report, validationConfig.getLocalProspectiveFile(), validationConfig.getRunId(),
-				validationConfig.getLocalManifestFile(), validationConfig.isWriteSucceses(), validationConfig.getUrl(), validationConfig.getStorageLocation());
+				validationConfig.getLocalManifestFile(), validationConfig.isWriteSucceses(), validationConfig.getUrl(), validationConfig.getStorageLocation(),
+				validationConfig.getFailureExportMax());
 		reportService.putFileIntoS3(reportStorage, new File(structuralTestRunner.getStructureTestReportFullPath()));
 		if (isFailed) {
 			reportService.writeResults(responseMap, State.FAILED, reportStorage);

--- a/execution-service/src/main/resources/execution-service-defaults.properties
+++ b/execution-service/src/main/resources/execution-service-defaults.properties
@@ -45,3 +45,4 @@ rvf.autoscaling.ec2SubnetId=
 #Drool Rule
 rvf.drools.rule.directory=snomed-drools-rules
 rvf.drools.rule.version=1.9
+rvf.drools.rule.repository=https://github.com/IHTSDO/snomed-drools-rules.git

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -9,6 +9,10 @@
     <artifactId>model</artifactId>
     <name>model</name>
 
+    <properties>
+        <snomed-drools.version>1.5.0-SNAPSHOT</snomed-drools.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -38,7 +42,7 @@
         <dependency>
             <groupId>org.ihtsdo.drools</groupId>
             <artifactId>snomed-drools-engine</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>${snomed-drools.version}</version>
         </dependency>
     </dependencies>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -43,6 +43,12 @@
             <groupId>org.ihtsdo.drools</groupId>
             <artifactId>snomed-drools-engine</artifactId>
             <version>${snomed-drools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.collections</groupId>
+                    <artifactId>google-collections</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/model/src/main/java/org/ihtsdo/rvf/entity/TestRunItem.java
+++ b/model/src/main/java/org/ihtsdo/rvf/entity/TestRunItem.java
@@ -232,6 +232,9 @@ public class TestRunItem implements Comparable<TestRunItem>{
 
 	@Override
 	public int compareTo(TestRunItem other) {
+		if(other.assertionUuid == null || this.assertionUuid == null) {
+			return 0;
+		}
 		return this.assertionUuid.compareTo(other.getAssertionUuid());
 	}
 	

--- a/validation-service/src/main/java/org/ihtsdo/rvf/validation/StructuralTestRunner.java
+++ b/validation-service/src/main/java/org/ihtsdo/rvf/validation/StructuralTestRunner.java
@@ -126,7 +126,7 @@ public class StructuralTestRunner implements InitializingBean{
 				logger.info("threshold = " + threshold);
 				
 				// Extract failed tests to report instead showing URL only which link to an physical test result
-				extractFailedTestsToReport(validationReport, report);
+				extractFailedTestsToReport(validationReport, report, maxFailuresExport);
 				
 				// bail out only if number of test failures exceeds threshold
 				if(threshold > getFailureThreshold()){


### PR DESCRIPTION
- Moved Drools rule git repo to configuration
- Fixed issue where RVF validation stops and throws error when assertion groups sent to RVF does not specify any Drools rule set  (e.g. assertions groups contains only "DanishEdition" without "dk-authoring", etc.)  
- Fixed issue where RVF validation throws error when assertion groups contains non-Drools rule sets (e.g. if assertion groups is "DanishEdition, dk-authoring, common-authoring",  RVF will stop and throw validation since DanishEdition is not a Drools rule set)
- Fixed special characters escaped by Gson in the report
- Fixed Drools rule report shows wrong executedRuleSet and wrong failure counts
- Fixed dependency conflict of Guava
- Improved message for structural test report


