### PR TITLE
MAINT-1679 Create empty-test assertion group for technical testing

### DIFF
--- a/api/src/main/java/org/ihtsdo/rvf/controller/TestUploadFileController.java
+++ b/api/src/main/java/org/ihtsdo/rvf/controller/TestUploadFileController.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FileUtils;
 import org.ihtsdo.rvf.entity.AssertionGroup;
+import org.ihtsdo.rvf.execution.service.ValidationRunner;
 import org.ihtsdo.rvf.execution.service.config.ValidationRunConfig;
 import org.ihtsdo.rvf.execution.service.MRCMValidationService.CharacteristicType;
 import org.ihtsdo.rvf.messaging.ValidationQueueManager;
@@ -309,6 +310,11 @@ public class TestUploadFileController {
 	private boolean isAssertionGroupsValid(List<String> validationGroups,
 			Map<String, String> responseMap) {
 		// check assertion groups
+
+		if (ValidationRunner.EMPTY_TEST_ASSERTION_GROUPS.equals(validationGroups)) {
+			return true;
+		}
+
 		List<AssertionGroup> groups = assertionService.getAssertionGroupsByNames(validationGroups);
 		if (groups.size() != validationGroups.size()) {
 			final List<String> found = new ArrayList<>();


### PR DESCRIPTION
It takes a lot of time to test and debug the messaging infrastructure between authoring-services, orchestration-service, rvf and the aag. This is because even using an assertion group with a minimum number of assertion the RVF still takes more than 10 minutes to build sql tables and run default tests. When developing this often needs to be repeated many times!

Create a empty-test assertion group which the RVF recognises and will return a successful report straight away (with tests run count of 0). This will significantly speed up development of messaging changes and could be used in deployment smoke testing.