### PR TITLE
Test prerequisites

### DIFF
--- a/src/main/java/org/ihtsdo/rvf/core/service/AssertionExecutionService.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/AssertionExecutionService.java
@@ -1,24 +1,27 @@
 package org.ihtsdo.rvf.core.service;
 
+import java.sql.*;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.naming.ConfigurationException;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.ihtsdo.rvf.core.data.model.*;
 import org.ihtsdo.rvf.core.service.config.MysqlExecutionConfig;
-import org.ihtsdo.rvf.importer.AssertionGroupImporter.ProductName;
+import org.ihtsdo.rvf.core.service.util.MySqlQueryTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import jakarta.annotation.Resource;
-import javax.naming.ConfigurationException;
-import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.*;
-import java.util.regex.Pattern;
 
 
 @Service
@@ -221,52 +224,10 @@ public List<TestRunItem> executeAssertionsConcurrently(List<Assertion> assertion
 	}
 
 	private List<String> transformSql(String[] parts, Assertion assertion, MysqlExecutionConfig config) throws ConfigurationException {
-		List<String> result = new ArrayList<>();
-		String defaultCatalog = dataSource.getDefaultCatalog();
-		String prospectiveSchema = config.getProspectiveVersion();
-		final String[] nameParts = config.getProspectiveVersion().split("_");
-		String defaultModuleId = StringUtils.hasLength(config.getDefaultModuleId()) ? config.getDefaultModuleId() : (nameParts.length >= 2 ? ProductName.toModuleId(nameParts[1]) : "NOT_SUPPLIED");
-		String includedModules = String.join(",", config.getIncludedModules());
-		String version = (nameParts.length >= 3 ? nameParts[2] : "NOT_SUPPLIED");
-
-		String previousReleaseSchema = config.getPreviousVersion();
-		String dependencyReleaseSchema = config.getExtensionDependencyVersion();
-		validateSchemas(config, prospectiveSchema, previousReleaseSchema);
-
-		for( String part : parts) {
-			if ((part.contains("<PREVIOUS>") && previousReleaseSchema == null)
-				|| (part.contains("<DEPENDENCY>") && dependencyReleaseSchema == null)) {
-				continue;
-			}
-
-			logger.debug("Original sql statement: {}", part);
-			final Pattern commentPattern = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
-			part = commentPattern.matcher(part).replaceAll("");
-			// replace all substitutions for exec
-			part = part.replaceAll("<RUNID>", String.valueOf(config.getExecutionId()));
-			part = part.replaceAll("<ASSERTIONUUID>", String.valueOf(assertion.getAssertionId()));
-			part = part.replaceAll("<MODULEID>", defaultModuleId);
-			part = part.replaceAll("<MODULEIDS>", includedModules);
-			part = part.replaceAll("<VERSION>", version);
-			// watch out for any 's that users might have introduced
-			part = part.replaceAll("qa_result", defaultCatalog+ "." + qaResulTableName);
-			part = part.replaceAll("<PROSPECTIVE>", prospectiveSchema);
-			part = part.replaceAll("<TEMP>", prospectiveSchema);
-			part = part.replaceAll("<INTERNATIONAL_MODULES>", internationalModules);
-			if (previousReleaseSchema != null) {
-				part = part.replaceAll("<PREVIOUS>", previousReleaseSchema);
-			}
-			if (dependencyReleaseSchema != null) {
-				part = part.replaceAll("<DEPENDENCY>", dependencyReleaseSchema);
-			}
-			part = part.replaceAll("<DELTA>", deltaTableSuffix);
-			part = part.replaceAll("<SNAPSHOT>", snapshotTableSuffix);
-			part = part.replaceAll("<FULL>", fullTableSuffix);
-			part = part.trim();
-			logger.debug("Transformed sql statement: {}", part);
-			result.add(part);
-		}
-		return result;
+		String qaResult = dataSource.getDefaultCatalog()+ "." + qaResulTableName;
+		MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
+		Map configMap = Map.of("qa_result",qaResult, "<ASSERTIONUUID>", String.valueOf(assertion.getAssertionId()));
+		return queryTransformer.transformSql(parts, config, configMap);
 	}
 
 	private static void validateSchemas(MysqlExecutionConfig config, String prospectiveSchema, String previousReleaseSchema) throws ConfigurationException {

--- a/src/main/java/org/ihtsdo/rvf/core/service/AssertionExecutionService.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/AssertionExecutionService.java
@@ -226,7 +226,7 @@ public List<TestRunItem> executeAssertionsConcurrently(List<Assertion> assertion
 	private List<String> transformSql(String[] parts, Assertion assertion, MysqlExecutionConfig config) throws ConfigurationException {
 		String qaResult = dataSource.getDefaultCatalog()+ "." + qaResulTableName;
 		MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
-		Map configMap = Map.of("qa_result",qaResult, "<ASSERTIONUUID>", String.valueOf(assertion.getAssertionId()));
+		Map configMap = Map.of("qa_result", qaResult, "<ASSERTIONUUID>", String.valueOf(assertion.getAssertionId()));
 		return queryTransformer.transformSql(parts, config, configMap);
 	}
 

--- a/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
@@ -1,0 +1,111 @@
+package org.ihtsdo.rvf.core.service.util;
+
+import com.facebook.presto.sql.parser.StatementSplitter;
+import com.google.common.collect.ImmutableSet;
+import org.ihtsdo.rvf.core.service.config.MysqlExecutionConfig;
+import org.ihtsdo.rvf.importer.AssertionGroupImporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.naming.ConfigurationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class MySqlQueryTransformer {
+    private final Logger logger = LoggerFactory.getLogger(MySqlQueryTransformer.class);
+
+    private static final String FAILED_TO_FIND_RVF_DB_SCHEMA = "Failed to find rvf db schema for ";
+
+    private String deltaTableSuffix = "d";
+    private String snapshotTableSuffix = "s";
+    private String fullTableSuffix = "f";
+    private static final String DEFAULT_DELIMITER = ";";
+    private static final String DELIMITER_REGEX_PATTERN = "^[ ]*(delimiter|DELIMITER)";
+
+    public List<String> transformSql(String[] parts, MysqlExecutionConfig config, final Map<String, String> configMap) throws ConfigurationException {
+        List<String> result = new ArrayList<>();
+        String prospectiveSchema = config.getProspectiveVersion();
+        final String[] nameParts = config.getProspectiveVersion().split("_");
+        String moduleId = (nameParts.length >= 2 ? AssertionGroupImporter.ProductName.toModuleId(nameParts[1]) : "NOT_SUPPLIED");
+        String version = (nameParts.length >= 3 ? nameParts[2] : "NOT_SUPPLIED");
+
+        String previousReleaseSchema = config.getPreviousVersion();
+        String dependencyReleaseSchema = config.getExtensionDependencyVersion();
+
+        //We need both these schemas to exist
+        if (prospectiveSchema == null) {
+            throw new ConfigurationException (FAILED_TO_FIND_RVF_DB_SCHEMA + prospectiveSchema);
+        }
+
+        if (config.isReleaseValidation() && !config.isFirstTimeRelease() && previousReleaseSchema == null) {
+            throw new ConfigurationException (FAILED_TO_FIND_RVF_DB_SCHEMA + previousReleaseSchema);
+        }
+        for( String part : parts) {
+            if ((part.contains("<PREVIOUS>") && previousReleaseSchema == null)
+                    || (part.contains("<DEPENDENCY>") && dependencyReleaseSchema == null)) {
+                continue;
+            }
+
+            logger.debug("Original sql statement: {}", part);
+            // remove all SQL comments - //TODO might throw errors for -- style comments
+            final Pattern commentPattern = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+            part = commentPattern.matcher(part).replaceAll("");
+            // replace all substitutions for exec
+            part = part.replaceAll("<RUNID>", String.valueOf(config.getExecutionId()));
+            part = part.replaceAll("<MODULEID>", moduleId);
+            part = part.replaceAll("<VERSION>", version);
+            // watch out for any 's that users might have introduced
+            part = part.replaceAll("<PROSPECTIVE>", prospectiveSchema);
+            part = part.replaceAll("<TEMP>", prospectiveSchema);
+            if (previousReleaseSchema != null) {
+                part = part.replaceAll("<PREVIOUS>", previousReleaseSchema);
+            }
+            if (dependencyReleaseSchema != null) {
+                part = part.replaceAll("<DEPENDENCY>", dependencyReleaseSchema);
+            }
+            part = part.replaceAll("<DELTA>", deltaTableSuffix);
+            part = part.replaceAll("<SNAPSHOT>", snapshotTableSuffix);
+            part = part.replaceAll("<FULL>", fullTableSuffix);
+            for(Map.Entry<String, String> configMapEntry: configMap.entrySet()){
+                part = part.replaceAll(configMapEntry.getKey(), configMapEntry.getValue());
+            }
+            part.trim();
+            logger.debug("Transformed sql statement: {}", part);
+            result.add(part);
+        }
+        return result;
+    }
+    /**
+     * Convert given sql file content to multiple statements
+     * @param sqlFileContent
+     * @return
+     */
+    public List<String> transformToStatements(String sqlFileContent){
+        String delimiter = DEFAULT_DELIMITER;
+        List<String> result = new ArrayList<>();
+        String[] sqlChunks = sqlFileContent.trim().split(DELIMITER_REGEX_PATTERN, Pattern.MULTILINE);
+        for (int i = 0; i < sqlChunks.length; i++) {
+            String sqlChunk = sqlChunks[i].trim();
+            if (!sqlChunk.isEmpty()) {
+                if (i > 0) {
+                    delimiter = sqlChunk.trim().replaceAll("(?s)^([^ \r\n]+).*$", "$1");
+                    sqlChunk = sqlChunk.trim().replaceAll("(?s)^[^ \r\n]+(.*)$", "$1").trim();
+                }
+                if (!sqlChunk.isEmpty()) {
+                    logger.debug("Executing pre-requisite SQL: " + sqlChunk);
+                    final StatementSplitter splitter = new StatementSplitter(sqlChunk, ImmutableSet.of(delimiter));
+                    if (splitter.getCompleteStatements() == null || splitter.getCompleteStatements().isEmpty()) {
+                        logger.warn(String.format("SQL statements not ending with %s %s",delimiter, sqlChunk) );
+                    }
+                    result= splitter.getCompleteStatements().stream().map(s -> s.statement()).collect(Collectors.toList());
+
+                }
+            }
+
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
@@ -48,7 +48,6 @@ public class MySqlQueryTransformer {
             throw new ConfigurationException (FAILED_TO_FIND_RVF_DB_SCHEMA + previousReleaseSchema);
         }
 
-        final String[] nameParts = config.getProspectiveVersion().split("_");
         String version = (nameParts.length >= 3 ? nameParts[2] : "NOT_SUPPLIED");
         String includedModules = config.getIncludedModules().stream().collect(Collectors.joining(","));
         String defaultModuleId = StringUtils.hasLength(config.getDefaultModuleId()) ? config.getDefaultModuleId() : (nameParts.length >= 2 ? AssertionGroupImporter.ProductName.toModuleId(nameParts[1]) : "NOT_SUPPLIED");

--- a/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
@@ -74,6 +74,8 @@ public class MySqlQueryTransformer {
             part = part.replaceAll("<DELTA>", deltaTableSuffix);
             part = part.replaceAll("<SNAPSHOT>", snapshotTableSuffix);
             part = part.replaceAll("<FULL>", fullTableSuffix);
+            part = part.replaceAll(Pattern.quote("[[:<:]]"),"\\\\b" );
+            part = part.replaceAll(Pattern.quote("[[:>:]]"),"\\\\b" );
             for(Map.Entry<String, String> configMapEntry: configMap.entrySet()){
                 part = part.replaceAll(configMapEntry.getKey(), configMapEntry.getValue());
             }

--- a/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
@@ -63,6 +63,10 @@ public class MySqlQueryTransformer {
             part = part.replaceAll("<MODULEID>", moduleId);
             part = part.replaceAll("<VERSION>", version);
             // watch out for any 's that users might have introduced
+            part = part.replaceAll("qa_result",
+                configMap.get("qa_result").startsWith(configMap.get("default_catalog"))
+                    ? configMap.get("default_catalog") + "." + configMap.get("qa_result")
+                        : configMap.get("qa_result"));
             part = part.replaceAll("<PROSPECTIVE>", prospectiveSchema);
             part = part.replaceAll("<TEMP>", prospectiveSchema);
             if (previousReleaseSchema != null) {
@@ -77,7 +81,9 @@ public class MySqlQueryTransformer {
             part = part.replaceAll(Pattern.quote("[[:<:]]"),"\\\\b" );
             part = part.replaceAll(Pattern.quote("[[:>:]]"),"\\\\b" );
             for(Map.Entry<String, String> configMapEntry: configMap.entrySet()){
-                part = part.replaceAll(configMapEntry.getKey(), configMapEntry.getValue());
+                if (!configMapEntry.getKey().equals("qa_result")) {
+                    part = part.replaceAll(configMapEntry.getKey(), configMapEntry.getValue());
+                }
             }
             part.trim();
             logger.debug("Transformed sql statement: {}", part);

--- a/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
@@ -27,7 +27,11 @@ public class MySqlQueryTransformer {
     private static final String DEFAULT_DELIMITER = ";";
     private static final String DELIMITER_REGEX_PATTERN = "^[ ]*(delimiter|DELIMITER)";
 
-    public List<String> transformSql(String[] parts, MysqlExecutionConfig config, final Map<String, String> configMap) throws ConfigurationException {
+    public List<String> transformSql(String[] parts, MysqlExecutionConfig config, final Map<String, String> configMap)
+            throws ConfigurationException {
+
+        logger.info("Config Map contains " + configMap.entrySet().stream().map(e -> e.getKey() + " : " + e.getValue()).collect(Collectors.joining(",")));
+
         List<String> result = new ArrayList<>();
         String prospectiveSchema = config.getProspectiveVersion();
         if (prospectiveSchema == null) {

--- a/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
@@ -7,6 +7,7 @@ import org.ihtsdo.rvf.core.service.config.MysqlExecutionConfig;
 import org.ihtsdo.rvf.importer.AssertionGroupImporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 import javax.naming.ConfigurationException;
 import java.util.ArrayList;
@@ -34,7 +35,6 @@ public class MySqlQueryTransformer {
         }
         final String[] nameParts = config.getProspectiveVersion().split("_");
         String moduleId = (nameParts.length >= 2 ? AssertionGroupImporter.ProductName.toModuleId(nameParts[1]) : "NOT_SUPPLIED");
-        String version = (nameParts.length >= 3 ? nameParts[2] : "NOT_SUPPLIED");
 
         String previousReleaseSchema = config.getPreviousVersion();
         String dependencyReleaseSchema = config.getExtensionDependencyVersion();
@@ -43,6 +43,11 @@ public class MySqlQueryTransformer {
         if (config.isReleaseValidation() && !config.isFirstTimeRelease() && previousReleaseSchema == null) {
             throw new ConfigurationException (FAILED_TO_FIND_RVF_DB_SCHEMA + previousReleaseSchema);
         }
+
+        final String[] nameParts = config.getProspectiveVersion().split("_");
+        String version = (nameParts.length >= 3 ? nameParts[2] : "NOT_SUPPLIED");
+        String includedModules = config.getIncludedModules().stream().collect(Collectors.joining(","));
+        String defaultModuleId = StringUtils.hasLength(config.getDefaultModuleId()) ? config.getDefaultModuleId() : (nameParts.length >= 2 ? AssertionGroupImporter.ProductName.toModuleId(nameParts[1]) : "NOT_SUPPLIED");
         for( String part : parts) {
             if ((part.contains("<PREVIOUS>") && previousReleaseSchema == null)
                     || (part.contains("<DEPENDENCY>") && dependencyReleaseSchema == null)) {

--- a/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
+++ b/src/main/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformer.java
@@ -67,10 +67,7 @@ public class MySqlQueryTransformer {
             part = part.replaceAll("<MODULEID>", moduleId);
             part = part.replaceAll("<VERSION>", version);
             // watch out for any 's that users might have introduced
-            part = part.replaceAll("qa_result",
-                configMap.get("qa_result").startsWith(configMap.get("default_catalog"))
-                    ? configMap.get("default_catalog") + "." + configMap.get("qa_result")
-                        : configMap.get("qa_result"));
+            part = part.replaceAll("qa_result", configMap.get("qa_result"));
             part = part.replaceAll("<PROSPECTIVE>", prospectiveSchema);
             part = part.replaceAll("<TEMP>", prospectiveSchema);
             if (previousReleaseSchema != null) {
@@ -85,7 +82,7 @@ public class MySqlQueryTransformer {
             part = part.replaceAll(Pattern.quote("[[:<:]]"),"\\\\b" );
             part = part.replaceAll(Pattern.quote("[[:>:]]"),"\\\\b" );
             for(Map.Entry<String, String> configMapEntry: configMap.entrySet()){
-                if (!configMapEntry.getKey().equals("qa_result")) {
+                if (configMapEntry.getKey().matches("^<[^>]+>$")) {
                     part = part.replaceAll(configMapEntry.getKey(), configMapEntry.getValue());
                 }
             }

--- a/src/main/java/org/ihtsdo/rvf/importer/AssertionsDatabaseImporter.java
+++ b/src/main/java/org/ihtsdo/rvf/importer/AssertionsDatabaseImporter.java
@@ -38,6 +38,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 	public class AssertionsDatabaseImporter {
 
 		private static final String CREATE_PROCEDURE = "CREATE PROCEDURE";
+	    private static final String CREATE_FUNCTION = "CREATE FUNCTION";
 		private static final Logger logger = LoggerFactory.getLogger(AssertionsDatabaseImporter.class);
 		private static final String RESOURCE_PATH_SEPARATOR = "/";
 
@@ -153,7 +154,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 			for (final StatementSplitter.Statement statement : splitter.getCompleteStatements()) {
 				String cleanedSql = statement.statement();
 				logger.debug("sql to be cleaned:" + cleanedSql);
-				if ( cleanedSql.startsWith(CREATE_PROCEDURE) || cleanedSql.startsWith(CREATE_PROCEDURE.toLowerCase())) {
+				if( cleanedSql.toUpperCase().startsWith(CREATE_PROCEDURE) || cleanedSql.toUpperCase().startsWith(CREATE_FUNCTION)) {
 					storedProcedureFound = true;
 				}
 				// Process SQL statement

--- a/src/main/java/org/ihtsdo/rvf/importer/AssertionsDatabaseImporter.java
+++ b/src/main/java/org/ihtsdo/rvf/importer/AssertionsDatabaseImporter.java
@@ -3,6 +3,7 @@ package org.ihtsdo.rvf.importer;
 import com.facebook.presto.sql.parser.StatementSplitter;
 import org.apache.commons.io.IOUtils;
 import org.ihtsdo.otf.resourcemanager.ResourceManager;
+import org.ihtsdo.otf.rest.exception.BusinessServiceException;
 import org.ihtsdo.rvf.core.data.model.Assertion;
 import org.ihtsdo.rvf.core.data.model.ExecutionCommand;
 import org.ihtsdo.rvf.core.data.model.Test;
@@ -296,7 +297,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 			uploadTest(assertion, sql, statements);
 		}
 
-		private void uploadTest (Assertion assertion, String originalSql, List<String> sqlStatements) {
+	protected void addPreRequisiteSqlToAssertion(final Assertion assertion, String preRequisiteSql)
+			throws RuntimeException {
+		MySqlQueryTransformer mySqlQueryTransformer = new MySqlQueryTransformer();
+		final List<String> sqlStatements = mySqlQueryTransformer.transformToStatements(preRequisiteSql);
+		uploadTest(assertion, preRequisiteSql, sqlStatements);
+	}
+
+	private void uploadTest (Assertion assertion, String originalSql, List<String> sqlStatements) {
 			final ExecutionCommand command = new ExecutionCommand();
 			command.setTemplate(originalSql);
 			command.setStatements(sqlStatements);
@@ -309,13 +317,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 			tests.add(test);
 			logger.debug("Adding tests for assertion id {}", assertion.getAssertionId());
 			assertionService.addTests(assertion, tests);
-		}
-
-		protected void addPreRequisiteSqlToAssertion(final Assertion assertion, String preRequisiteSql)
-				throws RuntimeException {
-			MySqlQueryTransformer mySqlQueryTransformer = new MySqlQueryTransformer();
-			final List<String> sqlStatements = mySqlQueryTransformer.transformToStatements(preRequisiteSql);
-			uploadTest(assertion, preRequisiteSql, sqlStatements);
 		}
 
 		private Map<String, String> getRvfSchemaMapping(String ratSchema){

--- a/src/test/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformerTest.java
+++ b/src/test/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformerTest.java
@@ -139,7 +139,8 @@ public class MySqlQueryTransformerTest {
         String testQaResult = "abc";
         when(config.getProspectiveVersion()).thenReturn("rvf_au_20221231_230619110027");
         when(config.getPreviousVersion()).thenReturn(String.valueOf(10));
-        Map configMap = Map.of("qa_result",testQaResult, "<ASSERTIONUUID>", String.valueOf(testAssertionId));
+        Map configMap = Map.of("qa_result",testQaResult,
+                "<ASSERTIONUUID>", String.valueOf(testAssertionId));
         List<String> result = queryTransformer.transformSql(sqlParts,config, configMap);
         assertEquals(1,result.size());
         assertFalse(result.get(0).contains("<PROSPECTIVE>"));

--- a/src/test/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformerTest.java
+++ b/src/test/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformerTest.java
@@ -132,7 +132,7 @@ public class MySqlQueryTransformerTest {
                 "\tunion\n" +
                 "        select referencedcomponentid, <ASSERTIONUUID> from <PROSPECTIVE>.simplerefset_<DELTA>\n" +
                 "\tunion\n" +
-                "        select referencedcomponentid from <PROSPECTIVE>.simplemaprefset_<DELTA>\n" +
+                "        select referencedcomponentid from <PROSPECTIVE>.simplemaprefset_<DELTA> and RLIKE Binary '[[:<:]]hexachlorophene[[:>:]]'\n" +
                 "    )";
         String[] sqlParts = {sql};
         String testAssertionId = "xyz";
@@ -143,11 +143,13 @@ public class MySqlQueryTransformerTest {
                 "<ASSERTIONUUID>", String.valueOf(testAssertionId));
         List<String> result = queryTransformer.transformSql(sqlParts,config, configMap);
         assertEquals(1,result.size());
-        assertFalse(result.get(0).contains("<PROSPECTIVE>"));
-        assertFalse(result.get(0).contains("<ASSERTIONUUID>"));
+        assertTrue(!result.get(0).contains("<PROSPECTIVE>"));
+        assertTrue(!result.get(0).contains("<ASSERTIONUUID>"));
         assertTrue(result.get(0).contains("rvf_au_20221231_230619110027.description_d"));
+        assertTrue(result.get(0).contains("'\\bhexachlorophene\\b'"));
         assertTrue(result.get(0).contains(testAssertionId));
     }
+
 
     @Test
     public void transformSqlMissingConfig() {

--- a/src/test/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformerTest.java
+++ b/src/test/java/org/ihtsdo/rvf/core/service/util/MySqlQueryTransformerTest.java
@@ -1,0 +1,167 @@
+package org.ihtsdo.rvf.core.service.util;
+
+import org.ihtsdo.otf.rest.exception.BusinessServiceException;
+import org.ihtsdo.rvf.core.service.config.MysqlExecutionConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.naming.ConfigurationException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class MySqlQueryTransformerTest {
+    @Mock
+    MysqlExecutionConfig config;
+    @Test
+    public void transformToStatements() throws BusinessServiceException {
+        MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
+        String sqlToTest = "DELIMITER //\n" +
+                "SET default_storage_engine=MYISAM//\n" +
+                "DROP TABLE IF EXISTS concept_active//\n" +
+                "CREATE TABLE concept_active ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AS\n" +
+                "SELECT * FROM concept_<SNAPSHOT> AS concepts WHERE active = 1//\n" +
+                "create unique index concept_active_id_ix on concept_active(id)//\n" +
+                "create index concept_active_effectivetime_ix on concept_active(effectivetime)//\n" +
+                "create index concept_active_definitionstatusid_ix on concept_active(definitionstatusid)//\n" +
+                "create index concept_active_moduleid_ix on concept_active(moduleid)//\n" +
+                "create index concept_active_active_ix on concept_active(active)//";
+        List<String> result = queryTransformer.transformToStatements(sqlToTest);
+        assertEquals(8, result.size());
+        assertEquals("create index concept_active_active_ix on concept_active(active)", result.get(7));
+        assertEquals("CREATE TABLE concept_active ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AS\n" +
+                "SELECT * FROM concept_<SNAPSHOT> AS concepts WHERE active = 1", result.get(2));
+    }
+    @Test
+    public void transformToStatementsWithSqlFunctions() throws BusinessServiceException {
+        MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
+        String sqlToTest = "DELIMITER // drop function if exists get_cr_ADRS_PT//\n" +
+                "create function get_cr_ADRS_PT(candidate bigint) returns varchar(4500)\n" +
+                "BEGIN RETURN (SELECT da.term FROM langrefset_active as lr join description_active as da\n" +
+                "                      on da.id = lr.referencedcomponentid WHERE lr.acceptabilityid = 900000000000548007 and conceptid = candidate); END//\n" +
+                "\n" +
+                "drop function if exists get_cr_FSN//\n" +
+                "create function get_cr_FSN(candidate bigint) returns varchar(4500)\n" +
+                "BEGIN RETURN (SELECT term FROM description_active where conceptId = candidate and typeId = 900000000000003001 and languageCode = 'en'); END//\n" +
+                "\n" +
+                "drop function if exists get_cr_PercentDefined//\n" +
+                "create function get_cr_PercentDefined(refset bigint) returns decimal(6, 4)\n" +
+                "BEGIN SET @refset = refset; SET @refsetSize = (select count(1) from simplerefset_active where refsetId = @refset); " +
+                "SET @definedCount = (select count(1) from concept_active where definitionStatusId = 900000000000073002 " +
+                "and id in (select referencedComponentId from simplerefset_active where refsetId = @refset)); " +
+                "RETURN CONVERT(@definedCount/ @refsetSize * 100,DECIMAL(6,4)); END//\n";
+        List<String> result = queryTransformer.transformToStatements(sqlToTest);
+        assertEquals(6, result.size());
+        assertTrue(result.get(0).startsWith("drop function if exists get_cr_ADRS_PT") );
+        assertTrue(result.get(5).startsWith("create function get_cr_PercentDefined(refset bigint)"));
+    }
+    @Test
+    public void transformToStatementsUsingDefaultDelimiter() throws BusinessServiceException {
+        MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
+        String sqlToTest = "SET default_storage_engine=MYISAM/;\n" +
+                "DROP TABLE IF EXISTS concept_active;\n" +
+                "CREATE TABLE concept_active ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AS\n" +
+                "SELECT * FROM concept_<SNAPSHOT> AS concepts WHERE active = 1;\n" +
+                "create unique index concept_active_id_ix on concept_active(id);\n" +
+                "create index concept_active_effectivetime_ix on concept_active(effectivetime);\n" +
+                "create index concept_active_definitionstatusid_ix on concept_active(definitionstatusid);\n" +
+                "create index concept_active_moduleid_ix on concept_active(moduleid);\n" +
+                "create index concept_active_active_ix on concept_active(active);";
+        List<String> result = queryTransformer.transformToStatements(sqlToTest);
+        assertEquals(8, result.size());
+        assertEquals("create index concept_active_active_ix on concept_active(active)", result.get(7));
+        assertEquals("CREATE TABLE concept_active ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AS\n" +
+                "SELECT * FROM concept_<SNAPSHOT> AS concepts WHERE active = 1", result.get(2));
+    }
+    @Test
+    public void transformToStatementInvalidDelimiter() {
+        MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
+        String sqlToTest = "DELIMITER // SET default_storage_engine=MYISAM/;\n" +
+                "DROP TABLE IF EXISTS concept_active;";
+        BusinessServiceException exception = assertThrows(BusinessServiceException.class, () -> {
+            queryTransformer.transformToStatements(sqlToTest);
+        });
+
+        String expectedMessagePattern = "SQL statements not ending with // SET default_storage_engine=MYISAM";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.startsWith(expectedMessagePattern));
+
+    }
+
+    @Test
+    public void transformSql() throws ConfigurationException {
+        MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
+        String sql = "insert into res_concepts_edited\n" +
+                "\tselect distinct id\n" +
+                "\tfrom <PROSPECTIVE>.concept_<SNAPSHOT>\n" +
+                "\twhere id in ( \n" +
+                "\t\tselect id from <PROSPECTIVE>.concept_<DELTA>\n" +
+                "    union \n" +
+                "        select conceptid from <PROSPECTIVE>.description_<DELTA>\n" +
+                "    union \n" +
+                "        select conceptid from <PROSPECTIVE>.textdefinition_<DELTA>\n" +
+                "    union \n" +
+                "        select sourceid from <PROSPECTIVE>.stated_relationship_<DELTA>\n" +
+                "    union\n" +
+                "        select referencedcomponentid from <PROSPECTIVE>.owlexpressionrefset_<DELTA>\n" +
+                "    union\n" +
+                "        select b.conceptid from <PROSPECTIVE>.langrefset_<DELTA> a \n" +
+                "        left join <PROSPECTIVE>.description_<SNAPSHOT> b on a.referencedcomponentid=b.id\n" +
+                "    union \n" +
+                "        select referencedcomponentid from <PROSPECTIVE>.attributevaluerefset_<DELTA>\n" +
+                "        where refsetid = '900000000000489007'\n" +
+                "    union \n" +
+                "        select a.conceptid from <PROSPECTIVE>.description_<DELTA> a\n" +
+                "        join <PROSPECTIVE>.attributevaluerefset_<DELTA> b on a.id = b.referencedcomponentid\n" +
+                "        where b.refsetid = '900000000000490003'\n" +
+                "\tunion\n" +
+                "        select referencedcomponentid\n" +
+                "        from <PROSPECTIVE>.associationrefset_<DELTA>\n" +
+                "        where refsetid in ('900000000000523009','900000000000526001','900000000000527005','900000000000530003','1186924009','1186921001')\n" +
+                "\tunion\n" +
+                "        select a.conceptid from <PROSPECTIVE>.description_<DELTA> a \n" +
+                "        join <PROSPECTIVE>.associationrefset_<DELTA> b on a.id = b.referencedcomponentid \n" +
+                "        where b.refsetid = '900000000000531004'\n" +
+                "\tunion\n" +
+                "        select referencedcomponentid, <ASSERTIONUUID> from <PROSPECTIVE>.simplerefset_<DELTA>\n" +
+                "\tunion\n" +
+                "        select referencedcomponentid from <PROSPECTIVE>.simplemaprefset_<DELTA>\n" +
+                "    )";
+        String[] sqlParts = {sql};
+        String testAssertionId = "xyz";
+        String testQaResult = "abc";
+        when(config.getProspectiveVersion()).thenReturn("rvf_au_20221231_230619110027");
+        when(config.getPreviousVersion()).thenReturn(String.valueOf(10));
+        Map configMap = Map.of("qa_result",testQaResult, "<ASSERTIONUUID>", String.valueOf(testAssertionId));
+        List<String> result = queryTransformer.transformSql(sqlParts,config, configMap);
+        assertEquals(1,result.size());
+        assertFalse(result.get(0).contains("<PROSPECTIVE>"));
+        assertFalse(result.get(0).contains("<ASSERTIONUUID>"));
+        assertTrue(result.get(0).contains("rvf_au_20221231_230619110027.description_d"));
+        assertTrue(result.get(0).contains(testAssertionId));
+    }
+
+    @Test
+    public void transformSqlMissingConfig() {
+        MySqlQueryTransformer queryTransformer = new MySqlQueryTransformer();
+        String sqlToTest = "SET default_storage_engine=MYISAM/;\n" +
+                "DROP TABLE IF EXISTS concept_active;";
+        String[] sqlParts = {sqlToTest};
+        ConfigurationException exception = assertThrows(ConfigurationException.class, () -> {
+            queryTransformer.transformSql(sqlParts,config, Collections.emptyMap());
+        });
+
+        String expectedMessagePattern = "Failed to find rvf db schema for null";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.startsWith(expectedMessagePattern));
+
+    }
+
+}


### PR DESCRIPTION
The PR adds support for a pre_requisites.sql file. This allows a user to provide a sql script that sets up any of their own test pre-requisites, like table, view, function creation. It runs after the RF2 has been imported, and before the tests start executing